### PR TITLE
fix: default_node_pool_enable_auto_scaling defaults true, not false

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -194,7 +194,7 @@ variable "default_node_pool_subnet_address_prefix" {
 }
 
 variable "default_node_pool_enable_auto_scaling" {
-  description = "(Optional) Whether to enable auto-scaler. Defaults to false."
+  description = "(Optional) Whether to enable auto-scaler. Defaults to true."
   type          = bool
   default       = true
 }


### PR DESCRIPTION
## Purpose
The description of the default behavior for tf var `default_node_pool_enable_auto_scaling` is wrong

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->